### PR TITLE
GradlePlugins cleanup, github action added

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,20 @@
+name: Verify
+
+on:
+  push:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+
+jobs:
+  Prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: verifies that prepare doesn't throw errors
+        run: VERSION=0.0.1-ci-SNAPSHOT ./prepare.sh
+      - name: publish to maven local
+        run: ./gradlew -Pskip.signing=true publishToMavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,6 @@ allprojects {
             withJavadocJar()
             withSourcesJar()
         }
-
     }
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {

--- a/prepare.sh
+++ b/prepare.sh
@@ -147,6 +147,7 @@ EOF
 cat << EOF > gradle.properties
 groupId=org.eclipse.edc
 javaVersion=11
+version=$VERSION
 defaultVersion=$VERSION
 annotationProcessorVersion=$VERSION
 edcGradlePluginsVersion=$VERSION
@@ -170,8 +171,8 @@ done
 if [ ! -z "$VERSION" ]
 then
   sed -i "s#defaultVersion=0.0.1-SNAPSHOT#defaultVersion=$VERSION#g" $(find . -name "gradle.properties")
-  sed -i "s#annotationProcessorVersion=0.0.1-SNAPSHOT#annotationProcessorVersion=$VERSION#g" $(find . -name "gradle.properties")
   sed -i "s#metaModelVersion=0.0.1-SNAPSHOT#metaModelVersion=$VERSION#g" $(find . -name "gradle.properties")
+  sed -i "s#annotationProcessorVersion=0.0.1-SNAPSHOT#annotationProcessorVersion=$VERSION#g" $(find . -name "gradle.properties")
 
   sed -i "s#edcGradlePluginsVersion=0.0.1-SNAPSHOT#edcGradlePluginsVersion=$VERSION#g" $(find . -name "gradle.properties")
 
@@ -221,12 +222,6 @@ sed -i "s#rootDir/resources/openapi/yaml/registration-service-api.yaml#rootDir/R
 
 # remove the dependency plugin part in connector
 sed -i '95,101d' Connector/build.gradle.kts
-
-# publish plugin needs to be removed from GradlePublish as it stays in the root
-sed -i '162,173d' GradlePlugins/build.gradle.kts
-sed -i '116,153d' GradlePlugins/build.gradle.kts
-sed -i '36,61d' GradlePlugins/build.gradle.kts
-sed -i '/gradle-nexus.publish-plugin/d' GradlePlugins/build.gradle.kts
 
 # not sure that the next part is needed
 cat << EOF >> Connector/build.gradle.kts


### PR DESCRIPTION
### what
cleans up prepare script according to the cleanup made on `GradlePlugins`.
add a ci job that tests the script and publish all the artifact locally.

### why
improve release process