### PR TITLE
feat(release): create all-in-one workflow

### DIFF
--- a/.github/workflows/publish-all-in-one.yaml
+++ b/.github/workflows/publish-all-in-one.yaml
@@ -1,0 +1,72 @@
+name: "Publish All Components"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: "The version that should be released. "
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: "The version that should be released. "
+
+env:
+  VERSION: ${{ github.event.inputs.version || inputs.version }}
+
+jobs:
+  secrets-presence:
+    name: "Check for required credentials"
+    runs-on: ubuntu-latest
+    outputs:
+      HAS_OSSRH: ${{ steps.secret-presence.outputs.HAS_OSSRH }}
+    steps:
+      - name: Check whether secrets exist
+        id: secret-presence
+        run: |
+          [ ! -z "${{ secrets.ORG_GPG_PASSPHRASE }}" ] &&
+          [ ! -z "${{ secrets.ORG_GPG_PRIVATE_KEY }}" ] &&
+          [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
+          exit 0
+
+  Publish-All-Components:
+    runs-on: ubuntu-latest
+    needs: [ secrets-presence ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+      - name: "Prepare all-in-one project"
+        run: |
+          ./prepare.sh
+
+      - name: "Display project structure"
+        run: ./gradlew projects
+
+      # Import GPG Key
+      - uses: eclipse-edc/.github/.github/actions/import-gpg-key@main
+        if: |
+          needs.secrets-presence.outputs.HAS_OSSRH
+        name: "Import GPG Key"
+        with:
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+
+      - name: "Publish all-in-one project"
+        if: |
+          needs.secrets-presence.outputs.HAS_OSSRH
+        env:
+          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+        run: |-
+          cmd=""
+          if [[ $VERSION != *-SNAPSHOT ]]
+          then
+            cmd="closeAndReleaseSonatypeStagingRepository";
+          fi
+          echo "Publishing Version $VERSION to Sonatype"
+          ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+


### PR DESCRIPTION
## What this PR changes/adds

Adds a `publish-all-in-one` workflow, that invokes the `./prepare.sh` script, and publishes the resulting project structure to OSSRH Staging or Maven Central.


## Why it does that

Gradually move away from Jenkins

## Further notes

This workflow in itself can be used to release versions "on-demand", i.e. through the `workflow_dispatch` event, but in the future can also be used to be invoked from other workflows (through the `workflow_call` event), e.g. when releasing, or when performing nightly builds


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
