### PR TITLE
feat: trigger workflows across repos (nightly)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,8 @@
 name: Build Nightly
 
 on:
+  schedule:
+    - cron: "0 1 * * *" # run at 01:00 UTC
   workflow_dispatch:
     inputs:
       version:
@@ -9,7 +11,6 @@ on:
       repo-owner:
         description: Owner/Org in which the nightly should get created
         default: "eclipse-edc"
-  # TODO: add cron trigger
 
 env:
   OWNER: ${{ github.event.inputs.repo-owner || inputs.repo-owner }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,88 @@
+name: Build Nightly
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic Version string to use for this nightly build
+        required: false
+      repo-owner:
+        description: Owner/Org in which the nightly should get created
+        default: "eclipse-edc"
+  # TODO: add cron trigger
+
+env:
+  OWNER: ${{ github.event.inputs.repo-owner || inputs.repo-owner }}
+  INPUT_VERSION: ${{ github.event.inputs.version || inputs.version }}
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  Secrets-Presence:
+    name: "Check for required credentials"
+    runs-on: ubuntu-latest
+    outputs:
+      HAS_OSSRH: ${{ steps.secret-presence.outputs.HAS_OSSRH }}
+    steps:
+      - name: Check whether secrets exist
+        id: secret-presence
+        run: |
+          [ ! -z "${{ secrets.ORG_GITHUB_BOT_USER }}" ] &&
+          [ ! -z "${{ secrets.ORG_GITHUB_BOT_USER }}" ] && echo "HAS_GH_PAT=true" >> $GITHUB_OUTPUT
+          exit 0
+  
+  Determine-Version:
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.get-version.outputs.VERSION }}
+    steps:
+      - name: "Extract version"
+        id: get-version
+        run: |
+          if [ -z ${{ env.INPUT_VERSION }} ]; then
+            wget -cq https://raw.githubusercontent.com/eclipse-edc/Connector/main/gradle.properties 
+            echo "VERSION=$(IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}') && echo $RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT)" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${{ env.INPUT_VERSION }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  Run-All-Tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    needs: [Secrets-Presence, Determine-Version]
+    if: |
+      needs.Secrets-Presence.outputs.HAS_GH_PAT
+    strategy:
+      fail-fast: false
+      matrix:
+        test-def: [ { owner: "${{ github.event.inputs.repo-owner }}", repo: "runtime-metamodel",    workflowfile: "ci.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "gradleplugins",        workflowfile: "test.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "connector",            workflowfile: "verify.yaml"},
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "identityhub",          workflowfile: "verify.yaml"},
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "registrationservice",  workflowfile: "verify.yaml"},
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "federatedcatalog",     workflowfile: "verify.yaml"},
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-azure",     workflowfile: "verify.yaml"},
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-aws",       workflowfile: "verify.yaml"},
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-gcp",       workflowfile: "verify.yaml"} ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Log version"
+        run: |
+          echo "Will build version ${{ needs.Determine-Version.outputs.VERSION }}"
+
+      - name: "Run test for ${{ matrix.test-def.repo }}"
+        run: |
+          chmod +x scripts/github_action.sh
+          ./scripts/github-action.sh ${{ matrix.test-def.owner }} ${{ matrix.test-def.repo }} ${{ matrix.test-def.workflowfile}} "" ${{ secrets.ORG_GITHUB_BOT_USER }} ${{ secrets.ORG_GITHUB_BOT_TOKEN }}
+
+  Publish-Components:
+    needs: [ Determine-Version, Run-All-Tests ]
+    uses: eclipse-edc/Release/.github/workflows/publish-all-in-one.yaml@main
+    secrets: inherit
+    with:
+      version: ${{ needs.Determine-Version.outputs.VERSION }}"

--- a/scripts/github_action.sh
+++ b/scripts/github_action.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+OWNER="$1"
+REPO_NAME="$2"
+WORKFLOW="$3"
+INPUTS="$4"
+USER="$5"
+PWD="$6"
+
+if [ "$#" -eq 5 ]; then
+  # use cURL with a Personal Access Token
+  echo "Using USER as personal access token for the GitHub API"
+  PARAMS=(-H "Authorization: Bearer $USER" -H "Accept: application/vnd.github.v3+json")
+
+elif [ "$#" -eq 6 ]; then
+  # use basic auth with cUrl
+  echo "Using USER/PWD authentication for the GitHub API"
+  PARAMS=(-u "$USER":"$PWD" -H "Accept: application/vnd.github.v3+json")
+
+else
+  echo "Usage: github_action.sh OWNER REPO_NAME WORKFLOW INPUTS USER [PWD]"
+  echo "OWNER     = the owner/org of the github repo"
+  echo "REPO_NAME = the name of the github repo"
+  echo "WORKFLOW  = the name of the workflow file to run, or its ID"
+  echo "INPUTS    = json representation of the workflow input"
+  echo "USER      = the username to use for authentication against the GitHub API, or an API token"
+  echo "PWD       = the password of USER. if not specified, USER will be interpreted as token"
+  exit 1
+fi
+
+REPO="$OWNER/$REPO_NAME"
+WORKFLOW_PATH="$REPO/actions/workflows/$WORKFLOW"
+
+
+if [ -z "${INPUTS}" ]; then
+  TRIGGER_BODY="{\"ref\": \"main\"}"
+else
+  TRIGGER_BODY="{\"ref\": \"main\", \"inputs\": ${INPUTS}}"
+fi
+
+echo "$WORKFLOW_PATH :: $(date) :: Trigger the workflow with ${TRIGGER_BODY}"
+STATUSCODE=$(curl --location --request POST --write-out "%{http_code}" "https://api.github.com/repos/${WORKFLOW_PATH}/dispatches" \
+  "${PARAMS[@]}" \
+  --data-raw "${TRIGGER_BODY}")
+
+if [ "$STATUSCODE" != 204 ]; then
+  echo "$WORKFLOW_PATH :: $(date) :: Cannot trigger workflow. Response code: $STATUSCODE"
+  exit 1
+fi
+
+# this is not working anymore, details: https://github.com/orgs/community/discussions/53266
+# numRuns=0
+# echo "$WORKFLOW_PATH :: $(date) :: Waiting for workflow to start"
+# while [ "$numRuns" -le "0" ]; do
+#   sleep 3
+#   # fetch the latest run triggered by a workflow_dispatch event
+#   runs=$(curl --fail -sSl "${PARAMS[@]}" -X GET "https://api.github.com/repos/${WORKFLOW_PATH}/runs?event=workflow_dispatch&status=in_progress")
+#   numRuns=$(echo "$runs" | jq -r '.total_count')
+#   echo "$WORKFLOW_PATH :: $(date) :: found $numRuns runs"
+# done
+
+status=
+echo "$WORKFLOW_PATH :: $(date) :: Waiting for workflow to start"
+while [ "$status" != "in_progress" ]; do
+  sleep 5
+  # fetch the latest run triggered by a workflow_dispatch event
+  runs=$(curl --fail -sSl "${PARAMS[@]}" -X GET "https://api.github.com/repos/${WORKFLOW_PATH}/runs?event=workflow_dispatch&per_page=1")
+  status=$(echo "$runs" | jq -r '.workflow_runs[0].status')
+  echo "$WORKFLOW_PATH :: $(date) :: status $status"
+done
+
+# contains the ID of the latest/most recent run
+RUN_ID=$(echo "$runs" | jq -r '.workflow_runs[0].id')
+
+echo "$WORKFLOW_PATH :: $(date) :: Waiting for run $RUN_ID to complete"
+while [ "$status" != "completed" ]; do
+  json=$(curl --fail -sSl "${PARAMS[@]}" -X GET "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}")
+  status=$(echo "$json" | jq -r '.status')
+  conclusion=$(echo "$json" | jq -r '.conclusion')
+  echo "$WORKFLOW_PATH :: $(date) :: Run $RUN_ID is $status"
+  if [ "$status" != "completed" ]; then
+    sleep 30 # sleep for 30 seconds before we check again, lets keep API requests low
+  fi
+done
+
+echo "$WORKFLOW_PATH :: $(date) :: Run completed, conclusion: $conclusion"
+
+if [ "$conclusion" != "success" ]; then
+  exit 1
+fi


### PR DESCRIPTION
## What this PR changes/adds

Adds a workflow that triggers a nightly snapshot build of the entire code base.

## Why it does that

Replace Jenkins

## Further notes


- `github_action.sh` script was copied over from the `JenkinsPipelines` repo
- could not yet fuly test this, because (force) pushing to `main` is disabled by branch protection rules, and i don't have the `ORG_GITHUB_USER|TOKEN` cred in my fork.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
