### PR TITLE
feat(build): add discord webhook

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -54,7 +54,7 @@ jobs:
   Run-All-Tests:
     name: "Run tests"
     runs-on: ubuntu-latest
-    needs: [Secrets-Presence, Determine-Version]
+    needs: [ Secrets-Presence, Determine-Version ]
     if: |
       needs.Secrets-Presence.outputs.HAS_GH_PAT
     strategy:
@@ -62,13 +62,13 @@ jobs:
       matrix:
         test-def: [ { owner: "${{ github.event.inputs.repo-owner }}", repo: "runtime-metamodel",    workflowfile: "ci.yaml" },
                     { owner: "${{ github.event.inputs.repo-owner }}", repo: "gradleplugins",        workflowfile: "test.yaml" },
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "connector",            workflowfile: "verify.yaml"},
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "identityhub",          workflowfile: "verify.yaml"},
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "registrationservice",  workflowfile: "verify.yaml"},
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "federatedcatalog",     workflowfile: "verify.yaml"},
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-azure",     workflowfile: "verify.yaml"},
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-aws",       workflowfile: "verify.yaml"},
-                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-gcp",       workflowfile: "verify.yaml"} ]
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "connector",            workflowfile: "verify.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "identityhub",          workflowfile: "verify.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "registrationservice",  workflowfile: "verify.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "federatedcatalog",     workflowfile: "verify.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-azure",     workflowfile: "verify.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-aws",       workflowfile: "verify.yaml" },
+                    { owner: "${{ github.event.inputs.repo-owner }}", repo: "technology-gcp",       workflowfile: "verify.yaml" } ]
 
     steps:
       - uses: actions/checkout@v3
@@ -87,3 +87,16 @@ jobs:
     with:
       version: ${{ needs.Determine-Version.outputs.VERSION }}
     secrets: inherit
+
+  Post-To-Discord:
+    needs: [ Publish-components, Determine-Version ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        name: "Invoke discord webhook"
+        if: always()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          title: "Nightly Build"
+          description: "Build and publish ${{ needs.Determine-Version.outputs.VERSION }}"
+          username: GitHub Actions


### PR DESCRIPTION
## What this PR changes/adds

Adds a discord webhook action to the nightly build.

## Why it does that

To inform Discord (channel `github-ci`) about the status of a build

## Further notes

A successful nightly build for example would look like this:
<img width="388" alt="image" src="https://github.com/eclipse-edc/Release/assets/43503240/6f680723-0785-4be4-8bfa-6522b2f3d4ef">

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
