### PR TITLE
chore: exclude registration service from nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -62,7 +62,6 @@ jobs:
                     { repo: "gradleplugins",        workflowfile: "test.yaml" },
                     { repo: "connector",            workflowfile: "verify.yaml" },
                     { repo: "identityhub",          workflowfile: "verify.yaml" },
-                    { repo: "registrationservice",  workflowfile: "verify.yaml" },
                     { repo: "federatedcatalog",     workflowfile: "verify.yaml" },
                     { repo: "technology-azure",     workflowfile: "verify.yaml" },
                     { repo: "technology-aws",       workflowfile: "verify.yaml" },


### PR DESCRIPTION
## What this PR changes/adds

_Briefly describe WHAT your pr changes, which features it adds/modifies._

## Why it does that

Registration Service is currently not compileable, as it depends on IH v0.3.1, and EDC latest, which does not provide some required classes anymore.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
