### PR TITLE
fix: discord webhook on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,7 @@ jobs:
           ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "trigger_snapshot.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
 
   Post-To-Discord:
-    needs: [ Release-Components, Determine-Version, Secrets-Presence ]
+    needs: [ Publish-Components, Release-Components, Determine-Version, Secrets-Presence ]
     if: "needs.Secrets-Presence.outputs.HAS_WEBHOOK && always()"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What this PR changes/adds

Invoking the discord webhook failed on release jobs (e.g. [here](https://github.com/eclipse-edc/Release/actions/runs/9057987341/job/24887029668#step:2:16)), and I noticed that the 
publish job did not depend on the `Publish-Components` job, which may have caused the empty result.


## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
