### PR TITLE
chore: exclude tech repos from build (nightly+release)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -62,10 +62,7 @@ jobs:
                     { repo: "gradleplugins",        workflowfile: "test.yaml" },
                     { repo: "connector",            workflowfile: "verify.yaml" },
                     { repo: "identityhub",          workflowfile: "verify.yaml" },
-                    { repo: "federatedcatalog",     workflowfile: "verify.yaml" },
-                    { repo: "technology-azure",     workflowfile: "verify.yaml" },
-                    { repo: "technology-aws",       workflowfile: "verify.yaml" },
-                    { repo: "technology-gcp",       workflowfile: "verify.yaml" } ]
+                    { repo: "federatedcatalog",     workflowfile: "verify.yaml" }]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,10 +54,7 @@ jobs:
                     { repo: "gradleplugins",        workflowfile: "test.yaml" },
                     { repo: "connector",            workflowfile: "verify.yaml" },
                     { repo: "identityhub",          workflowfile: "verify.yaml" },
-                    { repo: "federatedcatalog",     workflowfile: "verify.yaml" },
-                    { repo: "technology-azure",     workflowfile: "verify.yaml" },
-                    { repo: "technology-aws",       workflowfile: "verify.yaml" },
-                    { repo: "technology-gcp",       workflowfile: "verify.yaml" } ]
+                    { repo: "federatedcatalog",     workflowfile: "verify.yaml" } ]
     steps:
       - uses: actions/checkout@v3
 
@@ -87,10 +84,7 @@ jobs:
                     { repo: "gradleplugins",     workflowfile: "release-all-java.yml",    versionfield: "metamodel_version" },
                     { repo: "connector",         workflowfile: "release-edc.yml",         versionfield: "edc_version" },
                     { repo: "identityhub",       workflowfile: "release-identityhub.yml", versionfield: "ih_version" },
-                    { repo: "federatedcatalog",  workflowfile: "release-fcc.yml",         versionfield: "edc_version" },
-                    { repo: "technology-azure",  workflowfile: "release-tech-az.yml",     versionfield: "edc_version" },
-                    { repo: "technology-aws",    workflowfile: "release-tech-aws.yml",    versionfield: "edc_version" },
-                    { repo: "technology-gcp",    workflowfile: "release-tech-gcp.yml",    versionfield: "edc_version" } ]
+                    { repo: "federatedcatalog",  workflowfile: "release-fcc.yml",         versionfield: "edc_version" }]
     steps:
       - uses: actions/checkout@v3
       - name: "Log version"

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ FederatedCatalog/
 GradlePlugins/
 IdentityHub/
 RegistrationService/
-Technology-Azure/
-Technology-Aws/
-Technology-Gcp/
 Runtime-Metamodel/
 
 gradle.properties

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,25 +2,12 @@
 format.version = "1.1"
 
 [versions]
-assertj = "3.25.3"
-jackson = "2.17.0"
-edc = "0.6.0"
+jackson = "2.17.1"
+edc = "0.7.0"
 jetbrainsAnnotation = "24.1.0"
-junit = "5.10.2"
-mockito = "5.11.0"
 
 [libraries]
 edc-build = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
-jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
-jackson-datatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotation" }
-
-# test dependencies
-junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
-junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
-junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
-assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
-mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }

--- a/prepare.sh
+++ b/prepare.sh
@@ -12,9 +12,9 @@ toVersionCatalogName () {
 }
 
 # the components that need to be built
-#declare -a components=("Runtime-Metamodel" "GradlePlugins" "Connector" "IdentityHub" "RegistrationService" "FederatedCatalog" "Technology-Azure" "Technology-Aws" "Technology-Gcp")
+#declare -a components=("Runtime-Metamodel" "GradlePlugins" "Connector" "IdentityHub" "RegistrationService" "FederatedCatalog")
 # RegistrationService has been excluded because currently it can't work with the IATP implementation
-declare -a components=("Runtime-Metamodel" "GradlePlugins" "Connector" "IdentityHub" "FederatedCatalog" "Technology-Azure" "Technology-Aws" "Technology-Gcp")
+declare -a components=("Runtime-Metamodel" "GradlePlugins" "Connector" "IdentityHub" "FederatedCatalog")
 
 # create the base settings.gradle.kts file containing the version catalogs
 cat << EOF > settings.gradle.kts
@@ -56,15 +56,6 @@ dependencyResolutionManagement {
         // }
         create("federatedcatalog") {
           from("org.eclipse.edc:federated-catalog-versions:$VERSION")
-        }
-        create("technologyazure") {
-          from("org.eclipse.edc:technology-azure-versions:$VERSION")
-        }
-        create("technologyaws") {
-          from("org.eclipse.edc:technology-aws-versions:$VERSION")
-        }
-        create("technologygcp") {
-          from("org.eclipse.edc:technology-gcp-versions:$VERSION")
         }
         create("runtimemetamodel"){
           from("org.eclipse.edc:runtime-metamodel-versions:$VERSION")


### PR DESCRIPTION
## What this PR changes/adds

Excludes the Technology-* repositories from nightly builds and releases

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
