### PR TITLE
feat: add parameter for the target branch

### DIFF
--- a/.github/workflows/publish-all-in-one.yaml
+++ b/.github/workflows/publish-all-in-one.yaml
@@ -24,8 +24,10 @@ on:
         default: "main"
         description: "The branch which to publish. must exist in all repos!"
 
+# these environment variables will be read by prepare.sh
 env:
   VERSION: ${{ github.event.inputs.version || inputs.version }}
+  SOURCE_BRANCH: ${{ github.event.inputs.branch || inputs.branch }} 
 
 jobs:
   secrets-presence:

--- a/.github/workflows/publish-all-in-one.yaml
+++ b/.github/workflows/publish-all-in-one.yaml
@@ -7,12 +7,22 @@ on:
         type: string
         required: true
         description: "The version that should be released. "
+      branch: 
+        type: string
+        required: false
+        default: "main"
+        description: "The branch which to publish. must exist in all repos!"
   workflow_call:
     inputs:
       version:
         type: string
         required: true
         description: "The version that should be released. "
+      branch: 
+        type: string
+        required: false
+        default: "main"
+        description: "The branch which to publish. must exist in all repos!"
 
 env:
   VERSION: ${{ github.event.inputs.version || inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,14 @@ on:
       version:
         description: Semantic Version string to use for this release
         required: true
+      branch: 
+        description: Source ranch from which the version should be created. If omitted, 'main' is used.
+        required: false
+        default: "main"
 
 env:
   INPUT_VERSION: ${{ github.event.inputs.version || inputs.version }}
+  INPUT_SOURCE_BRANCH: ${{ github.event.inputs.branch || inputs.branch }}
 
 
 concurrency:
@@ -41,6 +46,16 @@ jobs:
         id: get-version
         run: echo "VERSION=${{ env.INPUT_VERSION }}" >> "$GITHUB_OUTPUT"
 
+  Determine-Branch:
+    # this looks to be necessary because some constructs as "with" are not able to get values from env
+    runs-on: ubuntu-latest
+    outputs: 
+      SOURCE_BRANCH: ${{ steps.get-branch.outputs.BRANCH }}
+    steps:
+      - name: "Get branch"
+        id: get-branch
+        run: echo "SOURCE_BRANCH=${{ env.INPUT_SOURCE_BRANCH }}" >> "$GITHUB_OUTPUT"
+
   Run-All-Tests:
     name: "Run tests"
     runs-on: ubuntu-latest
@@ -61,21 +76,23 @@ jobs:
       - name: "Run test for ${{ matrix.test-def.repo }}"
         run: |
           chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "${{ matrix.test-def.workflowfile}}" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
+          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "${{ matrix.test-def.workflowfile}}" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ env.INPUT_SOURCE_BRANCH }}"
 
   Publish-Components:
-    needs: [ Determine-Version, Run-All-Tests ]
-    uses: eclipse-edc/Release/.github/workflows/publish-all-in-one.yaml@main
+    needs: [ Determine-Version, Determine-Branch, Run-All-Tests ]
+    uses: ./.github/workflows/publish-all-in-one.yaml
     with:
       version: ${{ needs.Determine-Version.outputs.VERSION }}
+      branch: "${{ needs.Determine-Branch.outputs.SOURCE_BRANCH }}"
     secrets: inherit
 
   Release-Components:
     name: "Release Components"
     runs-on: ubuntu-latest
-    needs: [ Determine-Version, Publish-Components ]
+    needs: [Secrets-Presence, Determine-Version, Determine-Branch, Publish-Components ]
     if: |
-      needs.Secrets-Presence.outputs.HAS_GH_PAT
+      needs.Secrets-Presence.outputs.HAS_GH_PAT && 
+      needs.Determine-Branch.outputs.SOURCE_BRANCH == 'main'
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -103,7 +120,7 @@ jobs:
 
   Post-To-Discord:
     needs: [ Publish-Components, Release-Components, Determine-Version, Secrets-Presence ]
-    if: "needs.Secrets-Presence.outputs.HAS_WEBHOOK && always()"
+    if: needs.Secrets-Presence.outputs.HAS_WEBHOOK && always()
     runs-on: ubuntu-latest
     steps:
       - uses: sarisia/actions-status-discord@v1

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This gradle project prepares the EDC for a full release
 
 ## Run
+
 ```
+SOURCE_BRANCH=<git_source_branch> # this is optional
 VERSION=<version number> ./prepare.sh
 ```

--- a/prepare.sh
+++ b/prepare.sh
@@ -2,6 +2,12 @@
 
 set -ve
 
+# if SOURCE_BRANCH is not set, set it to "main"
+if [ -z "${SOURCE_BRANCH}" ]; then
+  echo "SOURCE_BRANCH variable not set, will default to 'main'"
+  SOURCE_BRANCH="main"
+fi
+
 # removes any dash, performs toLower
 toVersionCatalogName () {
   replacement=""
@@ -85,7 +91,7 @@ EOF
 for component in "${components[@]}"
 do
   rm -rf "$component"
-  git clone "https://github.com/eclipse-edc/$component"
+  git clone -b $SOURCE_BRANCH "https://github.com/eclipse-edc/$component"
 done
 
 # if the version variable is set, set it in the various gradle.properties and settings.gradle.kts files, otherwise leave the old version

--- a/scripts/github_action.sh
+++ b/scripts/github_action.sh
@@ -6,13 +6,14 @@ WORKFLOW="$3"
 INPUTS="$4"
 USER="$5"
 PWD="$6"
+BRANCH="$7"
 
 if [ "$#" -eq 5 ]; then
   # use cURL with a Personal Access Token
   echo "Using USER as personal access token for the GitHub API"
   PARAMS=(-H "Authorization: Bearer $USER" -H "Accept: application/vnd.github.v3+json")
 
-elif [ "$#" -eq 6 ]; then
+elif [ "$#" -ge 6 ]; then
   # use basic auth with cUrl
   echo "Using USER/PWD authentication for the GitHub API"
   PARAMS=(-u "$USER":"$PWD" -H "Accept: application/vnd.github.v3+json")
@@ -25,17 +26,22 @@ else
   echo "INPUTS    = json representation of the workflow input"
   echo "USER      = the username to use for authentication against the GitHub API, or an API token"
   echo "PWD       = the password of USER. if not specified, USER will be interpreted as token"
+  echo "BRANCH"   = the branch on which to execute the action. Defaults to "main"
   exit 1
 fi
 
 REPO="$OWNER/$REPO_NAME"
 WORKFLOW_PATH="$REPO/actions/workflows/$WORKFLOW"
 
+# run actions on "main" by default
+if [ -z "${BRANCH}" ]; then
+  BRANCH="main"
+fi
 
 if [ -z "${INPUTS}" ]; then
-  TRIGGER_BODY="{\"ref\": \"main\"}"
+  TRIGGER_BODY="{\"ref\": \"${BRANCH}\"}"
 else
-  TRIGGER_BODY="{\"ref\": \"main\", \"inputs\": ${INPUTS}}"
+  TRIGGER_BODY="{\"ref\": \"${BRANCH}\", \"inputs\": ${INPUTS}}"
 fi
 
 echo "$WORKFLOW_PATH :: $(date) :: Trigger the workflow with ${TRIGGER_BODY}"


### PR DESCRIPTION
## What this PR changes/adds

adds a `branch` parameter to the release workflow, so that it can be specified from which source branch the release is to be created.


## Why it does that

_Briefly state why the change was necessary._

## Further notes

- creating GitHub releases and posting to Discord is **skipped** if the source branch is not `main`. This is a first version, and support for GH releases could be added later.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
