### PR TITLE
build: implement new release workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,11 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-def: [ { repo: "runtime-metamodel",    workflowfile: "verify.yaml" },
-                    { repo: "gradleplugins",        workflowfile: "verify.yaml" },
-                    { repo: "connector",            workflowfile: "verify.yaml" },
-                    { repo: "identityhub",          workflowfile: "verify.yaml" },
-                    { repo: "federatedcatalog",     workflowfile: "verify.yaml" }]
+        repository: [ "runtime-metamodel", "gradleplugins", "connector", "identityhub", "federatedcatalog" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -70,10 +66,10 @@ jobs:
         run: |
           echo "Will build version ${{ needs.Determine-Version.outputs.VERSION }}"
 
-      - name: "Run test for ${{ matrix.test-def.repo }}"
+      - name: "Run test for ${{ matrix.repository }}"
         run: |
           chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "${{ matrix.test-def.workflowfile}}" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
+          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.repository }}" "verify.yaml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
 
   Publish-Components:
     needs: [ Determine-Version, Run-All-Tests ]

--- a/.github/workflows/publish-all-in-one.yaml
+++ b/.github/workflows/publish-all-in-one.yaml
@@ -6,7 +6,7 @@ on:
       version:
         type: string
         required: true
-        description: "The version that should be released. "
+        description: "The version that should be released."
       branch: 
         type: string
         required: false
@@ -24,52 +24,33 @@ on:
         default: "main"
         description: "The branch which to publish. must exist in all repos!"
 
-# these environment variables will be read by prepare.sh
+# these environment variables will be read by release-setup.sh
 env:
-  VERSION: ${{ github.event.inputs.version || inputs.version }}
-  SOURCE_BRANCH: ${{ github.event.inputs.branch || inputs.branch }} 
+  VERSION: ${{ inputs.version }}
+  SOURCE_BRANCH: ${{ inputs.branch }}
 
 jobs:
-  secrets-presence:
-    name: "Check for required credentials"
-    runs-on: ubuntu-latest
-    outputs:
-      HAS_OSSRH: ${{ steps.secret-presence.outputs.HAS_OSSRH }}
-    steps:
-      - name: Check whether secrets exist
-        id: secret-presence
-        run: |
-          [ ! -z "${{ secrets.ORG_GPG_PASSPHRASE }}" ] &&
-          [ ! -z "${{ secrets.ORG_GPG_PRIVATE_KEY }}" ] &&
-          [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
-          exit 0
 
   Publish-All-Components:
     runs-on: ubuntu-latest
-    needs: [ secrets-presence ]
     steps:
       - uses: actions/checkout@v4
-
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
-      - name: "Prepare all-in-one project"
+      - name: release setup
         run: |
-          ./prepare.sh
+          echo "Launch release setup on branch $SOURCE_BRANCH and version $VERSION"
+          ./release-setup.sh
 
       - name: "Display project structure"
         run: ./gradlew projects
 
-      # Import GPG Key
       - uses: eclipse-edc/.github/.github/actions/import-gpg-key@main
-        if: |
-          needs.secrets-presence.outputs.HAS_OSSRH
         name: "Import GPG Key"
         with:
           gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 
       - name: "Publish all-in-one project"
-        if: |
-          needs.secrets-presence.outputs.HAS_OSSRH
         env:
           OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
@@ -82,4 +63,3 @@ jobs:
           echo "Publishing Version $VERSION to Sonatype"
           ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}" \
               -Dorg.gradle.internal.network.retry.max.attempts=5 -Dorg.gradle.internal.network.retry.initial.backOff=5000
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,14 +6,8 @@ on:
         description: Semantic Version string to use for this release
         required: true
       branch: 
-        description: Source ranch from which the version should be created. If omitted, 'main' is used.
-        required: false
-        default: "main"
-
-env:
-  INPUT_VERSION: ${{ github.event.inputs.version || inputs.version }}
-  INPUT_SOURCE_BRANCH: ${{ github.event.inputs.branch || inputs.branch }}
-
+        description: Source branch from which the version should be created. 'main' should never be used, to create a release branch please trigger the "prepare" workflow before.
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,106 +15,51 @@ concurrency:
 
 jobs:
 
-  Secrets-Presence:
-    name: "Check for required credentials"
-    runs-on: ubuntu-latest
-    outputs:
-      HAS_GH_PAT: ${{ steps.secrets-presence.outputs.HAS_GH_PAT }}
-      HAS_WEBHOOK: ${{ steps.secrets-presence.outputs.HAS_WEBHOOK }}
-    steps:
-      - name: Check whether secrets exist
-        id: secrets-presence
-        run: |
-          [ ! -z "${{ secrets.ORG_GITHUB_BOT_USER }}" ] &&
-          [ ! -z "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" ] && echo "HAS_GH_PAT=true" >> $GITHUB_OUTPUT
-          [ ! -z "${{ secrets.DISCORD_GITHUB_CI_WEBHOOK }}" ] && echo "HAS_WEBHOOK=true" >> $GITHUB_OUTPUT
-          exit 0
-
-  Determine-Version:
-    # this looks to be necessary because some constructs as "with" are not able to get values from env
-    runs-on: ubuntu-latest
-    outputs:
-      VERSION: ${{ steps.get-version.outputs.VERSION }}
-    steps:
-      - name: "Extract version"
-        id: get-version
-        run: echo "VERSION=${{ env.INPUT_VERSION }}" >> "$GITHUB_OUTPUT"
-
-  Determine-Branch:
-    # this looks to be necessary because some constructs as "with" are not able to get values from env
-    runs-on: ubuntu-latest
-    outputs: 
-      SOURCE_BRANCH: ${{ steps.get-branch.outputs.BRANCH }}
-    steps:
-      - name: "Get branch"
-        id: get-branch
-        run: echo "SOURCE_BRANCH=${{ env.INPUT_SOURCE_BRANCH }}" >> "$GITHUB_OUTPUT"
-
   Run-All-Tests:
     name: "Run tests"
     runs-on: ubuntu-latest
-    needs: [ Secrets-Presence, Determine-Version ]
-    if: |
-      needs.Secrets-Presence.outputs.HAS_GH_PAT
     strategy:
       fail-fast: false
       matrix:
-        test-def: [ { repo: "runtime-metamodel",    workflowfile: "ci.yaml" },
-                    { repo: "gradleplugins",        workflowfile: "test.yaml" },
-                    { repo: "connector",            workflowfile: "verify.yaml" },
-                    { repo: "identityhub",          workflowfile: "verify.yaml" },
-                    { repo: "federatedcatalog",     workflowfile: "verify.yaml" } ]
+        repository: [ "runtime-metamodel", "gradleplugins", "connector", "identityhub", "federatedcatalog" ]
     steps:
       - uses: actions/checkout@v4
 
       - name: "Run test for ${{ matrix.test-def.repo }}"
         run: |
           chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "${{ matrix.test-def.workflowfile}}" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ env.INPUT_SOURCE_BRANCH }}"
+          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.repository }}" "verify.yaml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
 
   Publish-Components:
-    needs: [ Determine-Version, Determine-Branch, Run-All-Tests ]
+    needs: [ Run-All-Tests ]
     uses: ./.github/workflows/publish-all-in-one.yaml
     with:
-      version: ${{ needs.Determine-Version.outputs.VERSION }}
-      branch: "${{ needs.Determine-Branch.outputs.SOURCE_BRANCH }}"
+      version: ${{ inputs.version }}
+      branch: ${{ inputs.branch }}
     secrets: inherit
 
   Release-Components:
     name: "Release Components"
     runs-on: ubuntu-latest
-    needs: [Secrets-Presence, Determine-Version, Determine-Branch, Publish-Components ]
-    if: |
-      needs.Secrets-Presence.outputs.HAS_GH_PAT && 
-      needs.Determine-Branch.outputs.SOURCE_BRANCH == 'main'
+    needs: [ Publish-Components ]
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
-        test-def: [ { repo: "runtime-metamodel", workflowfile: "release-rm.yml",          versionfield: "edc_version" },
-                    { repo: "gradleplugins",     workflowfile: "release-all-java.yml",    versionfield: "metamodel_version" },
-                    { repo: "connector",         workflowfile: "release-edc.yml",         versionfield: "edc_version" },
-                    { repo: "identityhub",       workflowfile: "release-identityhub.yml", versionfield: "ih_version" },
-                    { repo: "federatedcatalog",  workflowfile: "release-fcc.yml",         versionfield: "edc_version" }]
+        repository: [ "runtime-metamodel", "gradleplugins", "connector", "identityhub", "federatedcatalog" ]
     steps:
       - uses: actions/checkout@v4
       - name: "Log version"
         run: |
-          echo "Will release version ${{ needs.Determine-Version.outputs.VERSION }}"
+          echo "Will release version ${{ inputs.version }}"
 
       - name: "Release ${{ matrix.test-def.repo }}"
         run: |
           chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "${{ matrix.test-def.workflowfile}}" "{\"${{ matrix.test-def.versionfield }}\": \"${{ needs.Determine-Version.outputs.VERSION }}\"}" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
-
-      - name: "Publish new SNAPSHOT version for ${{ matrix.test-def.repo }}"
-        run: |
-          chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.test-def.repo }}" "trigger_snapshot.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
+          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.repository }}" "release.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
 
   Post-To-Discord:
-    needs: [ Publish-Components, Release-Components, Determine-Version, Secrets-Presence ]
-    if: needs.Secrets-Presence.outputs.HAS_WEBHOOK && always()
+    needs: [ Publish-Components, Release-Components ]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: sarisia/actions-status-discord@v1
@@ -129,6 +68,6 @@ jobs:
           webhook: ${{ secrets.DISCORD_GITHUB_CI_WEBHOOK }}
           # if the publishing is skipped, that means the preceding test run failed
           status: ${{ needs.Publish-Components.result == 'skipped' && 'Failure' || needs.Publish-Components.result }}
-          title: "Nightly Build"
-          description: "Build and publish ${{ needs.Determine-Version.outputs.VERSION }}"
+          title: "Release Core"
+          description: "Build and publish ${{ inputs.version }}"
           username: GitHub Actions

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -9,13 +9,16 @@ on:
       - '**.md'
 
 jobs:
-  Prepare:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
-      - name: verifies that prepare doesn't throw errors
-        run: VERSION=0.0.1-ci-SNAPSHOT ./prepare.sh
+      - name: verifies that release setup works correctly
+        run: |
+          export VERSION=0.0.1-ci-SNAPSHOT 
+          export SOURCE_BRANCH=main 
+          ./release-setup.sh
       - name: publish to maven local
         run: |
           ./gradlew -Pskip.signing=true publishToMavenLocal \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # EDC Release
 
-This gradle project prepares the EDC for a full release
+EDC core repositories release
 
 ## Run
 
-```
-SOURCE_BRANCH=<git_source_branch> # this is optional
-VERSION=<version number> ./prepare.sh
+```shell
+export SOURCE_BRANCH=<git_source_branch>
+export VERSION=<version number>
+./release-setup.sh
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.8.1"
+edc = "0.7.3"
 
 [libraries]
 edc-build = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }


### PR DESCRIPTION
## What this PR changes/adds

Configure new release process according to the [related DR](https://github.com/eclipse-edc/docs/tree/541a66101ea73ab314ad372f538b102b612ee5d5/developer/decision-records/2024-08-26-new-release-process)

## Why it does that

release

## Further notes

- new releases will start only from dedicated branch, never from `main` again. 

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
