### PR TITLE
build: trigger technology release automatically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,23 @@ jobs:
           chmod +x ./scripts/github_action.sh
           ./scripts/github_action.sh "eclipse-edc" "${{ matrix.repository }}" "release.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
 
+  Release-Technology-Repositories:
+    runs-on: ubuntu-latest
+    needs: [ Release-Components ]
+    strategy:
+      matrix:
+        repository: [ "technology-aws", "technology-azure", "technology-gcp" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Log version"
+        run: |
+          echo "Will release version ${{ inputs.version }}"
+
+      - name: "Release ${{ matrix.test-def.repo }}"
+        run: |
+          chmod +x ./scripts/github_action.sh
+          ./scripts/github_action.sh "eclipse-edc" "${{ matrix.repository }}" "release.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
+
   Post-To-Discord:
     needs: [ Publish-Components, Release-Components ]
     if: always()


### PR DESCRIPTION
## What this PR changes/adds

Trigger "technology-*" repo release automatically at the end of the release of the core components.
The `Wait-Build-Plugin` job should ensure that the maven artifacts needed for these releases are available. 

## Why it does that

automation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
